### PR TITLE
fix: type mobile pill text styles for strict checks

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import { Link } from "expo-router";
-import { View, Text, Pressable, ScrollView } from "react-native";
+import { View, Text, Pressable, ScrollView, ViewStyle, TextStyle } from "react-native";
 import { colors, radius, shadow } from "../../theme";
 import { useEffect, useState } from "react";
 import { loadProfile, Profile } from "../../utils/storage";
@@ -49,5 +49,14 @@ function Row({ label, value }:{label:string; value:string}) {
     </View>
   );
 }
-const pill = (bg:string)=>({ backgroundColor: bg, paddingVertical:10, paddingHorizontal:12, borderRadius: 9999 });
-const pillText = ()=>({ color:"#fff", fontWeight:"800" });
+const pill = (bg:string): ViewStyle => ({
+  backgroundColor: bg,
+  paddingVertical:10,
+  paddingHorizontal:12,
+  borderRadius: 9999,
+});
+
+const pillText = (): TextStyle => ({
+  color:"#fff",
+  fontWeight:"800",
+});


### PR DESCRIPTION
## Summary
- annotate the pill helper styles on the mobile home tab so React Native knows their types
- import the needed `ViewStyle` and `TextStyle` helpers instead of relying on widened literals

## Testing
- npx tsc --noEmit (mobile)
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68cc7914f1f08328a6348c5b9c4d6a46